### PR TITLE
bindgen: Only generate bindings for `I?ADLX*` items

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,16 +1,11 @@
 use std::{env, path::PathBuf};
 
 fn main() {
-    println!("cargo:rerun-if-changed=wrapper.h");
+    println!("cargo:rerun-if-changed=src/adlx/wrapper.h");
 
     let bindings = bindgen::Builder::default()
         .header("src/adlx/wrapper.h")
-        .blocklist_type("_IMAGE_TLS_DIRECTORY64")
-        .blocklist_type("IMAGE_TLS_DIRECTORY64")
-        .blocklist_type("IMAGE_TLS_DIRECTORY")
-        .blocklist_type("PIMAGE_TLS_DIRECTORY64")
-        .blocklist_type("PIMAGE_TLS_DIRECTORY")
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .allowlist_item("I?ADLX\\w+")
         .generate()
         .expect("failed to generate adlx bindings");
 


### PR DESCRIPTION
These headers include `Windows.h`, resulting in a 335k(!!) bindings file that is very hard for `rustc` (and `rust-analyzer`) to process. In addition `cargo` seems to fail generating a proper fingerprint for it, resulting in repeated re-runs of `build.rs` that take upwards of 2 minutes each.

Rather than declaring every API that we _do not want_, list only the regex-based API for items that we _do want_ to generate bindings for.
