### PR TITLE
Further improve ADLX interface wrapper to have a notion of the current `Impl`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
         run: cargo clippy --workspace --all-targets -- -D warnings
       - name: Cargo test
         run: cargo test --workspace
+      - name: Cargo doc
+        env:
+          RUSTDOCFLAGS: -Dwarnings
+        run: cargo doc --all --all-features
 
   rust-msrv:
     name: Build-test MSRV (1.74) with minal crate dependencies

--- a/src/adlx/interface.rs
+++ b/src/adlx/interface.rs
@@ -3,8 +3,13 @@
 use crate::bindings as ffi;
 
 /// # Safety
-/// By implementing this trait you guarantee that
+/// All `unsafe` implementers of this trait should guarantee [`ffi::IADLXInterface`] is the base
+/// type.
+///
+/// The struct must have the same layout as [`*mut IADLXInterface`][ffi::IADLXInterface], preferably
+/// in terms of [`InterfaceImpl`] for automatic refcount management.
 pub unsafe trait Interface: Sized {
+    type Impl;
     type Vtable;
     const IID: &'static str;
 
@@ -15,60 +20,61 @@ pub unsafe trait Interface: Sized {
         unsafe { self.assume_vtable::<Self>() }
     }
 
-    /// Cast this interface as a reference to the supplied interfaces `Vtable`
+    /// Cast this interface as a reference to the supplied interfaces [`Self::Vtable`]
     ///
     /// # Safety
     ///
     /// This is safe if `T` is an equivalent interface to `Self` or a super interface.
-    /// In other words, `T::Vtable` must be equivalent to the beginning of `Self::Vtable`.
+    /// In other words, `T::Vtable` must be equivalent to the beginning of [`Self::Vtable`].
     #[doc(hidden)]
     unsafe fn assume_vtable<T: Interface>(&self) -> &T::Vtable {
-        let base_vtable = self.as_adlx_interface().pVtbl;
+        let base_vtable = (*self.imp().cast::<ffi::IADLXInterface>()).pVtbl;
         &*<*const _>::cast(base_vtable)
     }
 
-    /// # Safety
-    /// All `unsafe` implementers of this trait should guarantee [`ffi::IADLXInterface`] is the base type.
-    ///
-    /// This function exists so that not everyone needs to implement this function in terms of `{ self.0 }`.
-    fn as_adlx_interface(&self) -> &ffi::IADLXInterface {
-        unsafe { std::mem::transmute_copy(self) }
-    }
-
-    /// Creates an `Interface` by taking ownership of the `raw` COM interface pointer.
+    /// Creates an [`Interface`] by taking ownership of the `raw` COM/ADLX interface pointer.
     ///
     /// # Safety
     ///
-    /// The `raw` pointer must be owned by the caller and represent a valid COM interface pointer. In other words,
-    /// it must point to a vtable beginning with the `IUnknown` function pointers and match the vtable of `Interface`.
-    unsafe fn from_raw(raw: *mut std::ffi::c_void) -> Self {
+    /// The `raw` pointer must be owned by the caller and represent a valid ADLX interface pointer.
+    /// In other words, it must point to a vtable beginning with the [`ffi::IADLXInterfaceVtbl`]
+    /// function pointers and match the vtable of [`Self::Vtable`].
+    unsafe fn from_raw(raw: *mut Self::Impl) -> Self {
         std::mem::transmute_copy(&raw)
     }
 
-    // fn from_abi(ptr: *mut c_void) -> Self {}
+    // TODO: With a generic on `InterfaceImpl` trait implementers (via derive-macro-generated
+    // implementation) could provide their type-safe pointer value
+    fn imp(&self) -> *mut Self::Impl {
+        unsafe { std::mem::transmute_copy(self) }
+    }
 }
 
 /// All `IADLX*` types are expected to own this object, and access the vtable by implementing
-/// [`Interface`] with the appropriate type set in [`Interface::Vtable`].  Owning this type
-/// means proper [`Drop`] and [`Clone`] semantics, and less manual conversions like e.g.
-/// `as_adlx_interface()`.
+/// [`Interface`] with the appropriate owning type set in [`Interface::Impl`] and corresponding
+/// vtable in [`Interface::Vtable`].
+///
+/// Owning this type means proper [`Drop`] and [`Clone`] semantics, and less manual conversions like
+/// e.g. [`Interface::imp()`].
 // TODO(Marijn): We could also achieve that by creating a little macro that provides the conversions, while being more type-safe!
 #[derive(Debug)]
 #[repr(transparent)]
-pub struct ADLXInterface(*mut ffi::IADLXInterface);
+#[doc(alias = "IADLXInterface")]
+pub struct InterfaceImpl(*mut ffi::IADLXInterface);
 
-unsafe impl Interface for ADLXInterface {
+unsafe impl Interface for InterfaceImpl {
+    type Impl = ffi::IADLXInterface;
     type Vtable = ffi::IADLXInterfaceVtbl;
     const IID: &'static str = "IADLXInterface";
 }
 
-impl Drop for ADLXInterface {
+impl Drop for InterfaceImpl {
     fn drop(&mut self) {
         let _rc = unsafe { (self.vtable().Release.unwrap())(self.0) };
     }
 }
 
-impl Clone for ADLXInterface {
+impl Clone for InterfaceImpl {
     fn clone(&self) -> Self {
         let _rc = unsafe { (self.vtable().Acquire.unwrap())(self.0) };
         Self(self.0)

--- a/src/adlx/system.rs
+++ b/src/adlx/system.rs
@@ -1,17 +1,16 @@
 use std::mem::MaybeUninit;
 
-use crate::bindings::{self as ffi, IADLXInterface};
-
 use super::{
-    interface::Interface,
+    interface::{Interface, InterfaceImpl},
     result::{Error, Result},
 };
+use crate::bindings as ffi;
 
 /// [`System`] is a singleton interface.  It looks similar to but is not compatible with
 /// [`Interface`].
 #[derive(Debug)]
-#[doc(alias = "IADLXSystem")]
 #[repr(transparent)]
+#[doc(alias = "IADLXSystem")]
 pub struct System(*mut ffi::IADLXSystem);
 
 impl System {
@@ -59,7 +58,7 @@ impl System {
                 interface.as_mut_ptr(),
             )
         };
-        Error::from_result(result).map(|()| unsafe { I::from_raw(interface.assume_init()) })
+        Error::from_result(result).map(|()| unsafe { I::from_raw(interface.assume_init().cast()) })
     }
     // #[doc(alias = "GetDisplaysServices")]
     // pub fn GetDisplaysServices(&self) -> Result<()> {
@@ -127,11 +126,12 @@ impl System {
 }
 
 #[derive(Clone, Debug)]
-#[doc(alias = "IADLXSystem1")]
 #[repr(transparent)]
-pub struct System1(IADLXInterface);
+#[doc(alias = "IADLXSystem1")]
+pub struct System1(InterfaceImpl);
 
 unsafe impl Interface for System1 {
+    type Impl = ffi::IADLXSystem1;
     type Vtable = ffi::IADLXSystem1Vtbl;
     const IID: &'static str = "IADLXSystem1";
 }
@@ -140,11 +140,9 @@ impl System1 {
     // #[doc(alias = "GetPowerTuningServices")]
     // pub fn power_tuning_services(&self) -> Result<PowerTuningServices> {
     //     let mut ret = MaybeUninit::uninit();
-    //     let result = self.vtable().GetPowerTuningServices(
-    //         // TODO: Make it easier to get the actual self pointer type, while maintaining lifetiming from IADLXInterface
-    //         self.0.cast(),
-    //         ret.as_mut_ptr(),
-    //     );
+    //     let result = unsafe {
+    //         (self.vtable().GetPowerTuningServices.unwrap())(self.imp(), ret.as_mut_ptr())
+    //     };
     //     let ret = Error::from_result_with_assume_init_on_success(result, ret)?;
     //     Ok(PowerTuningServices::from_raw(ret))
     // }


### PR DESCRIPTION
Make casting to the current implementation possible via a new `fn imp()`.
