### PR TITLE
Post-push review

### DIFF
--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -25,7 +25,7 @@ impl Gpu {
         let result = unsafe { (self.vtable().VendorId.unwrap())(self.as_raw(), name.as_mut_ptr()) };
 
         Error::from_result_with_assume_init_on_success(result, name)
-            .map(|name| unsafe { CStr::from_ptr(name) }.to_str().unwrap())
+            .map(|x| unsafe { CStr::from_ptr(x) }.to_str().unwrap())
     }
     #[doc(alias = "ASICFamilyType")]
     pub fn asic_family_type(&self) -> Result<ffi::ADLX_ASIC_FAMILY_TYPE> {
@@ -44,12 +44,12 @@ impl Gpu {
         Error::from_result_with_assume_init_on_success(result, type_)
     }
     #[doc(alias = "IsExternal")]
-    pub fn is_external(&self) -> Result<ffi::adlx_bool> {
+    pub fn is_external(&self) -> Result<bool> {
         let mut is_external = MaybeUninit::uninit();
         let result =
             unsafe { (self.vtable().IsExternal.unwrap())(self.as_raw(), is_external.as_mut_ptr()) };
 
-        Error::from_result_with_assume_init_on_success(result, is_external)
+        Error::from_result_with_assume_init_on_success(result, is_external).map(|x| x != 0)
     }
     /// <https://gpuopen.com/manuals/adlx/adlx-_d_o_x__i_a_d_l_x_g_p_u__name/#doxid-d-o-x-i-a-d-l-x-g-p-u-name>
     #[doc(alias = "Name")]
@@ -60,20 +60,22 @@ impl Gpu {
         Error::from_result_with_assume_init_on_success(result, name)
             .map(|name| unsafe { CStr::from_ptr(name) }.to_str().unwrap())
     }
-    // #[doc(alias = "DriverPath")]
-    // pub fn DriverPath(&self) -> Result<()> {
-    //     let mut x = MaybeUninit::uninit();
-    //     let result = unsafe { (self.vtable().DriverPath.unwrap())(self.as_raw(), x.as_mut_ptr()) };
+    #[doc(alias = "DriverPath")]
+    pub fn driver_path(&self) -> Result<&str> {
+        let mut x = MaybeUninit::uninit();
+        let result = unsafe { (self.vtable().DriverPath.unwrap())(self.as_raw(), x.as_mut_ptr()) };
 
-    //     Error::from_result_with_assume_init_on_success(result, x)
-    // }
-    // #[doc(alias = "PNPString")]
-    // pub fn PNPString(&self) -> Result<()> {
-    //     let mut x = MaybeUninit::uninit();
-    //     let result = unsafe { (self.vtable().PNPString.unwrap())(self.as_raw(), x.as_mut_ptr()) };
+        Error::from_result_with_assume_init_on_success(result, x)
+            .map(|x| unsafe { CStr::from_ptr(x) }.to_str().unwrap())
+    }
+    #[doc(alias = "PNPString")]
+    pub fn pnp_string(&self) -> Result<&str> {
+        let mut x = MaybeUninit::uninit();
+        let result = unsafe { (self.vtable().PNPString.unwrap())(self.as_raw(), x.as_mut_ptr()) };
 
-    //     Error::from_result_with_assume_init_on_success(result, x)
-    // }
+        Error::from_result_with_assume_init_on_success(result, x)
+            .map(|x| unsafe { CStr::from_ptr(x) }.to_str().unwrap())
+    }
     // #[doc(alias = "HasDesktops")]
     // pub fn HasDesktops(&self) -> Result<()> {
     //     let mut x = MaybeUninit::uninit();
@@ -88,13 +90,14 @@ impl Gpu {
 
         Error::from_result_with_assume_init_on_success(result, x)
     }
-    // #[doc(alias = "VRAMType")]
-    // pub fn VRAMType(&self) -> Result<()> {
-    //     let mut x = MaybeUninit::uninit();
-    //     let result = unsafe { (self.vtable().VRAMType.unwrap())(self.as_raw(), x.as_mut_ptr()) };
+    #[doc(alias = "VRAMType")]
+    pub fn vram_type(&self) -> Result<&str> {
+        let mut x = MaybeUninit::uninit();
+        let result = unsafe { (self.vtable().VRAMType.unwrap())(self.as_raw(), x.as_mut_ptr()) };
 
-    //     Error::from_result_with_assume_init_on_success(result, x)
-    // }
+        Error::from_result_with_assume_init_on_success(result, x)
+            .map(|x| unsafe { CStr::from_ptr(x) }.to_str().unwrap())
+    }
     // #[doc(alias = "BIOSInfo")]
     // pub fn BIOSInfo(&self) -> Result<()> {
     //     let mut x = MaybeUninit::uninit();
@@ -103,35 +106,38 @@ impl Gpu {
     //     Error::from_result_with_assume_init_on_success(result, x)
     // }
     #[doc(alias = "DeviceId")]
-    pub fn device_id(&self) -> Result<String> {
+    pub fn device_id(&self) -> Result<&str> {
         let mut x = MaybeUninit::uninit();
         let result = unsafe { (self.vtable().DeviceId.unwrap())(self.as_raw(), x.as_mut_ptr()) };
 
         Error::from_result_with_assume_init_on_success(result, x)
-            .map(|x| unsafe { CStr::from_ptr(x).to_str().unwrap().to_string() })
+            .map(|x| unsafe { CStr::from_ptr(x) }.to_str().unwrap())
     }
-    // #[doc(alias = "RevisionId")]
-    // pub fn RevisionId(&self) -> Result<()> {
-    //     let mut x = MaybeUninit::uninit();
-    //     let result = unsafe { (self.vtable().RevisionId.unwrap())(self.as_raw(), x.as_mut_ptr()) };
+    #[doc(alias = "RevisionId")]
+    pub fn revision_id(&self) -> Result<&str> {
+        let mut x = MaybeUninit::uninit();
+        let result = unsafe { (self.vtable().RevisionId.unwrap())(self.as_raw(), x.as_mut_ptr()) };
 
-    //     Error::from_result_with_assume_init_on_success(result, x)
-    // }
-    // #[doc(alias = "SubSystemId")]
-    // pub fn SubSystemId(&self) -> Result<()> {
-    //     let mut x = MaybeUninit::uninit();
-    //     let result = unsafe { (self.vtable().SubSystemId.unwrap())(self.as_raw(), x.as_mut_ptr()) };
+        Error::from_result_with_assume_init_on_success(result, x)
+            .map(|x| unsafe { CStr::from_ptr(x) }.to_str().unwrap())
+    }
+    #[doc(alias = "SubSystemId")]
+    pub fn sub_system_id(&self) -> Result<&str> {
+        let mut x = MaybeUninit::uninit();
+        let result = unsafe { (self.vtable().SubSystemId.unwrap())(self.as_raw(), x.as_mut_ptr()) };
 
-    //     Error::from_result_with_assume_init_on_success(result, x)
-    // }
-    // #[doc(alias = "SubSystemVendorId")]
-    // pub fn SubSystemVendorId(&self) -> Result<()> {
-    //     let mut x = MaybeUninit::uninit();
-    //     let result =
-    //         unsafe { (self.vtable().SubSystemVendorId.unwrap())(self.as_raw(), x.as_mut_ptr()) };
+        Error::from_result_with_assume_init_on_success(result, x)
+            .map(|x| unsafe { CStr::from_ptr(x) }.to_str().unwrap())
+    }
+    #[doc(alias = "SubSystemVendorId")]
+    pub fn sub_system_vendor_id(&self) -> Result<&str> {
+        let mut x = MaybeUninit::uninit();
+        let result =
+            unsafe { (self.vtable().SubSystemVendorId.unwrap())(self.as_raw(), x.as_mut_ptr()) };
 
-    //     Error::from_result_with_assume_init_on_success(result, x)
-    // }
+        Error::from_result_with_assume_init_on_success(result, x)
+            .map(|x| unsafe { CStr::from_ptr(x) }.to_str().unwrap())
+    }
     #[doc(alias = "UniqueId")]
     pub fn unique_id(&self) -> Result<i32> {
         let mut x = MaybeUninit::uninit();

--- a/src/gpu_list.rs
+++ b/src/gpu_list.rs
@@ -9,7 +9,7 @@ use super::{
 };
 
 /// <https://gpuopen.com/manuals/adlx/adlx-_d_o_x__i_a_d_l_x_g_p_u_list/>
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[repr(transparent)]
 #[doc(alias = "IADLXGPUList")]
 pub struct GpuList(List);

--- a/src/gpu_metrics.rs
+++ b/src/gpu_metrics.rs
@@ -1,10 +1,9 @@
 use std::{mem::MaybeUninit, ops::Deref};
 
-use crate::list::List;
-
 use super::{
     ffi,
     interface::{Interface, InterfaceImpl},
+    list::List,
     result::{Error, Result},
 };
 
@@ -202,316 +201,304 @@ unsafe impl Interface for GpuMetricsSupport {
 impl GpuMetricsSupport {
     #[doc(alias = "IsSupportedGPUUsage")]
     pub fn is_supported_gpu_usage(&self) -> Result<bool> {
-        unsafe {
-            let mut supported = MaybeUninit::uninit();
-            let res =
-                (self.vtable().IsSupportedGPUUsage.unwrap())(self.as_raw(), supported.as_mut_ptr());
-            Error::from_result_with_assume_init_on_success(res, supported)
-                .map(|supported| supported != 0)
-        }
+        let mut supported = MaybeUninit::uninit();
+        let res = unsafe {
+            (self.vtable().IsSupportedGPUUsage.unwrap())(self.as_raw(), supported.as_mut_ptr())
+        };
+        Error::from_result_with_assume_init_on_success(res, supported)
+            .map(|supported| supported != 0)
     }
     #[doc(alias = "IsSupportedGPUClockSpeed")]
     pub fn is_supported_gpu_clock_speed(&self) -> Result<bool> {
-        unsafe {
-            let mut supported = MaybeUninit::uninit();
-            let res = (self.vtable().IsSupportedGPUClockSpeed.unwrap())(
-                self.as_raw(),
-                supported.as_mut_ptr(),
-            );
-            Error::from_result_with_assume_init_on_success(res, supported)
-                .map(|supported| supported != 0)
-        }
+        let mut supported = MaybeUninit::uninit();
+        let res = unsafe {
+            (self.vtable().IsSupportedGPUClockSpeed.unwrap())(self.as_raw(), supported.as_mut_ptr())
+        };
+        Error::from_result_with_assume_init_on_success(res, supported)
+            .map(|supported| supported != 0)
     }
     #[doc(alias = "IsSupportedGPUVRAMClockSpeed")]
     pub fn is_supported_gpu_vram_clock_speed(&self) -> Result<bool> {
-        unsafe {
-            let mut supported = MaybeUninit::uninit();
-            let res = (self.vtable().IsSupportedGPUVRAMClockSpeed.unwrap())(
+        let mut supported = MaybeUninit::uninit();
+        let res = unsafe {
+            (self.vtable().IsSupportedGPUVRAMClockSpeed.unwrap())(
                 self.as_raw(),
                 supported.as_mut_ptr(),
-            );
-            Error::from_result_with_assume_init_on_success(res, supported)
-                .map(|supported| supported != 0)
-        }
+            )
+        };
+        Error::from_result_with_assume_init_on_success(res, supported)
+            .map(|supported| supported != 0)
     }
     #[doc(alias = "IsSupportedGPUTemperature")]
     pub fn is_supported_gpu_temperature(&self) -> Result<bool> {
-        unsafe {
-            let mut supported = MaybeUninit::uninit();
-            let res = (self.vtable().IsSupportedGPUTemperature.unwrap())(
+        let mut supported = MaybeUninit::uninit();
+        let res = unsafe {
+            (self.vtable().IsSupportedGPUTemperature.unwrap())(
                 self.as_raw(),
                 supported.as_mut_ptr(),
-            );
-            Error::from_result_with_assume_init_on_success(res, supported)
-                .map(|supported| supported != 0)
-        }
+            )
+        };
+        Error::from_result_with_assume_init_on_success(res, supported)
+            .map(|supported| supported != 0)
     }
     #[doc(alias = "IsSupportedGPUHotspotTemperature")]
     pub fn is_supported_gpu_hotspot_temperature(&self) -> Result<bool> {
-        unsafe {
-            let mut supported = MaybeUninit::uninit();
-            let res = (self.vtable().IsSupportedGPUHotspotTemperature.unwrap())(
+        let mut supported = MaybeUninit::uninit();
+        let res = unsafe {
+            (self.vtable().IsSupportedGPUHotspotTemperature.unwrap())(
                 self.as_raw(),
                 supported.as_mut_ptr(),
-            );
-            Error::from_result_with_assume_init_on_success(res, supported)
-                .map(|supported| supported != 0)
-        }
+            )
+        };
+        Error::from_result_with_assume_init_on_success(res, supported)
+            .map(|supported| supported != 0)
     }
     #[doc(alias = "IsSupportedGPUPower")]
     pub fn is_supported_gpu_power(&self) -> Result<bool> {
-        unsafe {
-            let mut supported = MaybeUninit::uninit();
-            let res =
-                (self.vtable().IsSupportedGPUPower.unwrap())(self.as_raw(), supported.as_mut_ptr());
-            Error::from_result_with_assume_init_on_success(res, supported)
-                .map(|supported| supported != 0)
-        }
+        let mut supported = MaybeUninit::uninit();
+        let res = unsafe {
+            (self.vtable().IsSupportedGPUPower.unwrap())(self.as_raw(), supported.as_mut_ptr())
+        };
+        Error::from_result_with_assume_init_on_success(res, supported)
+            .map(|supported| supported != 0)
     }
     #[doc(alias = "IsSupportedGPUTotalBoardPower")]
     pub fn is_supported_gpu_total_board_power(&self) -> Result<bool> {
-        unsafe {
-            let mut supported = MaybeUninit::uninit();
-            let res = (self.vtable().IsSupportedGPUTotalBoardPower.unwrap())(
+        let mut supported = MaybeUninit::uninit();
+        let res = unsafe {
+            (self.vtable().IsSupportedGPUTotalBoardPower.unwrap())(
                 self.as_raw(),
                 supported.as_mut_ptr(),
-            );
-            Error::from_result_with_assume_init_on_success(res, supported)
-                .map(|supported| supported != 0)
-        }
+            )
+        };
+        Error::from_result_with_assume_init_on_success(res, supported)
+            .map(|supported| supported != 0)
     }
     #[doc(alias = "IsSupportedGPUFanSpeed")]
     pub fn is_supported_gpu_fan_speed(&self) -> Result<bool> {
-        unsafe {
-            let mut supported = MaybeUninit::uninit();
-            let res = (self.vtable().IsSupportedGPUFanSpeed.unwrap())(
-                self.as_raw(),
-                supported.as_mut_ptr(),
-            );
-            Error::from_result_with_assume_init_on_success(res, supported)
-                .map(|supported| supported != 0)
-        }
+        let mut supported = MaybeUninit::uninit();
+        let res = unsafe {
+            (self.vtable().IsSupportedGPUFanSpeed.unwrap())(self.as_raw(), supported.as_mut_ptr())
+        };
+        Error::from_result_with_assume_init_on_success(res, supported)
+            .map(|supported| supported != 0)
     }
     #[doc(alias = "IsSupportedGPUVRAM")]
     pub fn is_supported_gpu_vram(&self) -> Result<bool> {
-        unsafe {
-            let mut supported = MaybeUninit::uninit();
-            let res =
-                (self.vtable().IsSupportedGPUVRAM.unwrap())(self.as_raw(), supported.as_mut_ptr());
-            Error::from_result_with_assume_init_on_success(res, supported)
-                .map(|supported| supported != 0)
-        }
+        let mut supported = MaybeUninit::uninit();
+        let res = unsafe {
+            (self.vtable().IsSupportedGPUVRAM.unwrap())(self.as_raw(), supported.as_mut_ptr())
+        };
+        Error::from_result_with_assume_init_on_success(res, supported)
+            .map(|supported| supported != 0)
     }
     #[doc(alias = "IsSupportedGPUVoltage")]
     pub fn is_supported_gpu_voltage(&self) -> Result<bool> {
-        unsafe {
-            let mut supported = MaybeUninit::uninit();
-            let res = (self.vtable().IsSupportedGPUVoltage.unwrap())(
-                self.as_raw(),
-                supported.as_mut_ptr(),
-            );
-            Error::from_result_with_assume_init_on_success(res, supported)
-                .map(|supported| supported != 0)
-        }
+        let mut supported = MaybeUninit::uninit();
+        let res = unsafe {
+            (self.vtable().IsSupportedGPUVoltage.unwrap())(self.as_raw(), supported.as_mut_ptr())
+        };
+        Error::from_result_with_assume_init_on_success(res, supported)
+            .map(|supported| supported != 0)
     }
     #[doc(alias = "IsSupportedGPUIntakeTemperature")]
     pub fn is_supported_gpu_intake_temperature(&self) -> Result<bool> {
-        unsafe {
-            let mut supported = MaybeUninit::uninit();
-            let res = (self.vtable().IsSupportedGPUIntakeTemperature.unwrap())(
+        let mut supported = MaybeUninit::uninit();
+        let res = unsafe {
+            (self.vtable().IsSupportedGPUIntakeTemperature.unwrap())(
                 self.as_raw(),
                 supported.as_mut_ptr(),
-            );
-            Error::from_result_with_assume_init_on_success(res, supported)
-                .map(|supported| supported != 0)
-        }
+            )
+        };
+        Error::from_result_with_assume_init_on_success(res, supported)
+            .map(|supported| supported != 0)
     }
 
     #[doc(alias = "GetGPUUsageRange")]
-    pub fn gpu_usage_range(&self) -> Result<std::ops::Range<i32>> {
-        unsafe {
-            let mut min = MaybeUninit::uninit();
-            let mut max = MaybeUninit::uninit();
-            let res = (self.vtable().GetGPUUsageRange.unwrap())(
+    pub fn gpu_usage_range(&self) -> Result<std::ops::RangeInclusive<i32>> {
+        let mut min = MaybeUninit::uninit();
+        let mut max = MaybeUninit::uninit();
+        let res = unsafe {
+            (self.vtable().GetGPUUsageRange.unwrap())(
                 self.as_raw(),
                 min.as_mut_ptr(),
                 max.as_mut_ptr(),
-            );
-            Error::from_result(res).map(|()| {
-                let min = min.assume_init();
-                let max = max.assume_init();
-                min..max
-            })
-        }
+            )
+        };
+        Error::from_result(res).map(|()| {
+            let min = unsafe { min.assume_init() };
+            let max = unsafe { max.assume_init() };
+            min..=max
+        })
     }
     #[doc(alias = "GetGPUClockSpeedRange")]
-    pub fn gpu_clock_speed_range(&self) -> Result<std::ops::Range<i32>> {
-        unsafe {
-            let mut min = MaybeUninit::uninit();
-            let mut max = MaybeUninit::uninit();
-            let res = (self.vtable().GetGPUClockSpeedRange.unwrap())(
+    pub fn gpu_clock_speed_range(&self) -> Result<std::ops::RangeInclusive<i32>> {
+        let mut min = MaybeUninit::uninit();
+        let mut max = MaybeUninit::uninit();
+        let res = unsafe {
+            (self.vtable().GetGPUClockSpeedRange.unwrap())(
                 self.as_raw(),
                 min.as_mut_ptr(),
                 max.as_mut_ptr(),
-            );
-            Error::from_result(res).map(|()| {
-                let min = min.assume_init();
-                let max = max.assume_init();
-                min..max
-            })
-        }
+            )
+        };
+        Error::from_result(res).map(|()| {
+            let min = unsafe { min.assume_init() };
+            let max = unsafe { max.assume_init() };
+            min..=max
+        })
     }
     #[doc(alias = "GetGPUVRAMClockSpeedRange")]
-    pub fn gpu_vram_clock_speed_range(&self) -> Result<std::ops::Range<i32>> {
-        unsafe {
-            let mut min = MaybeUninit::uninit();
-            let mut max = MaybeUninit::uninit();
-            let res = (self.vtable().GetGPUVRAMClockSpeedRange.unwrap())(
+    pub fn gpu_vram_clock_speed_range(&self) -> Result<std::ops::RangeInclusive<i32>> {
+        let mut min = MaybeUninit::uninit();
+        let mut max = MaybeUninit::uninit();
+        let res = unsafe {
+            (self.vtable().GetGPUVRAMClockSpeedRange.unwrap())(
                 self.as_raw(),
                 min.as_mut_ptr(),
                 max.as_mut_ptr(),
-            );
-            Error::from_result(res).map(|()| {
-                let min = min.assume_init();
-                let max = max.assume_init();
-                min..max
-            })
-        }
+            )
+        };
+        Error::from_result(res).map(|()| {
+            let min = unsafe { min.assume_init() };
+            let max = unsafe { max.assume_init() };
+            min..=max
+        })
     }
     #[doc(alias = "GetGPUTemperatureRange")]
-    pub fn gpu_temperature_range(&self) -> Result<std::ops::Range<i32>> {
-        unsafe {
-            let mut min = MaybeUninit::uninit();
-            let mut max = MaybeUninit::uninit();
-            let res = (self.vtable().GetGPUTemperatureRange.unwrap())(
+    pub fn gpu_temperature_range(&self) -> Result<std::ops::RangeInclusive<i32>> {
+        let mut min = MaybeUninit::uninit();
+        let mut max = MaybeUninit::uninit();
+        let res = unsafe {
+            (self.vtable().GetGPUTemperatureRange.unwrap())(
                 self.as_raw(),
                 min.as_mut_ptr(),
                 max.as_mut_ptr(),
-            );
-            Error::from_result(res).map(|()| {
-                let min = min.assume_init();
-                let max = max.assume_init();
-                min..max
-            })
-        }
+            )
+        };
+        Error::from_result(res).map(|()| {
+            let min = unsafe { min.assume_init() };
+            let max = unsafe { max.assume_init() };
+            min..=max
+        })
     }
     #[doc(alias = "GetGPUHotspotTemperatureRange")]
-    pub fn gpu_hotspot_temperature_range(&self) -> Result<std::ops::Range<i32>> {
-        unsafe {
-            let mut min = MaybeUninit::uninit();
-            let mut max = MaybeUninit::uninit();
-            let res = (self.vtable().GetGPUHotspotTemperatureRange.unwrap())(
+    pub fn gpu_hotspot_temperature_range(&self) -> Result<std::ops::RangeInclusive<i32>> {
+        let mut min = MaybeUninit::uninit();
+        let mut max = MaybeUninit::uninit();
+        let res = unsafe {
+            (self.vtable().GetGPUHotspotTemperatureRange.unwrap())(
                 self.as_raw(),
                 min.as_mut_ptr(),
                 max.as_mut_ptr(),
-            );
-            Error::from_result(res).map(|()| {
-                let min = min.assume_init();
-                let max = max.assume_init();
-                min..max
-            })
-        }
+            )
+        };
+        Error::from_result(res).map(|()| {
+            let min = unsafe { min.assume_init() };
+            let max = unsafe { max.assume_init() };
+            min..=max
+        })
     }
     #[doc(alias = "GetGPUPowerRange")]
-    pub fn gpu_power_range(&self) -> Result<std::ops::Range<i32>> {
-        unsafe {
-            let mut min = MaybeUninit::uninit();
-            let mut max = MaybeUninit::uninit();
-            let res = (self.vtable().GetGPUPowerRange.unwrap())(
+    pub fn gpu_power_range(&self) -> Result<std::ops::RangeInclusive<i32>> {
+        let mut min = MaybeUninit::uninit();
+        let mut max = MaybeUninit::uninit();
+        let res = unsafe {
+            (self.vtable().GetGPUPowerRange.unwrap())(
                 self.as_raw(),
                 min.as_mut_ptr(),
                 max.as_mut_ptr(),
-            );
-            Error::from_result(res).map(|()| {
-                let min = min.assume_init();
-                let max = max.assume_init();
-                min..max
-            })
-        }
+            )
+        };
+        Error::from_result(res).map(|()| {
+            let min = unsafe { min.assume_init() };
+            let max = unsafe { max.assume_init() };
+            min..=max
+        })
     }
     #[doc(alias = "GetGPUFanSpeedRange")]
-    pub fn gpu_fan_speed_range(&self) -> Result<std::ops::Range<i32>> {
-        unsafe {
-            let mut min = MaybeUninit::uninit();
-            let mut max = MaybeUninit::uninit();
-            let res = (self.vtable().GetGPUFanSpeedRange.unwrap())(
+    pub fn gpu_fan_speed_range(&self) -> Result<std::ops::RangeInclusive<i32>> {
+        let mut min = MaybeUninit::uninit();
+        let mut max = MaybeUninit::uninit();
+        let res = unsafe {
+            (self.vtable().GetGPUFanSpeedRange.unwrap())(
                 self.as_raw(),
                 min.as_mut_ptr(),
                 max.as_mut_ptr(),
-            );
-            Error::from_result(res).map(|()| {
-                let min = min.assume_init();
-                let max = max.assume_init();
-                min..max
-            })
-        }
+            )
+        };
+        Error::from_result(res).map(|()| {
+            let min = unsafe { min.assume_init() };
+            let max = unsafe { max.assume_init() };
+            min..=max
+        })
     }
     #[doc(alias = "GetGPUVRAMRange")]
-    pub fn gpu_vran_range(&self) -> Result<std::ops::Range<i32>> {
-        unsafe {
-            let mut min = MaybeUninit::uninit();
-            let mut max = MaybeUninit::uninit();
-            let res = (self.vtable().GetGPUVRAMRange.unwrap())(
+    pub fn gpu_vran_range(&self) -> Result<std::ops::RangeInclusive<i32>> {
+        let mut min = MaybeUninit::uninit();
+        let mut max = MaybeUninit::uninit();
+        let res = unsafe {
+            (self.vtable().GetGPUVRAMRange.unwrap())(
                 self.as_raw(),
                 min.as_mut_ptr(),
                 max.as_mut_ptr(),
-            );
-            Error::from_result(res).map(|()| {
-                let min = min.assume_init();
-                let max = max.assume_init();
-                min..max
-            })
-        }
+            )
+        };
+        Error::from_result(res).map(|()| {
+            let min = unsafe { min.assume_init() };
+            let max = unsafe { max.assume_init() };
+            min..=max
+        })
     }
     #[doc(alias = "GetGPUVoltageRange")]
-    pub fn gpu_voltage_range(&self) -> Result<std::ops::Range<i32>> {
-        unsafe {
-            let mut min = MaybeUninit::uninit();
-            let mut max = MaybeUninit::uninit();
-            let res = (self.vtable().GetGPUVoltageRange.unwrap())(
+    pub fn gpu_voltage_range(&self) -> Result<std::ops::RangeInclusive<i32>> {
+        let mut min = MaybeUninit::uninit();
+        let mut max = MaybeUninit::uninit();
+        let res = unsafe {
+            (self.vtable().GetGPUVoltageRange.unwrap())(
                 self.as_raw(),
                 min.as_mut_ptr(),
                 max.as_mut_ptr(),
-            );
-            Error::from_result(res).map(|()| {
-                let min = min.assume_init();
-                let max = max.assume_init();
-                min..max
-            })
-        }
+            )
+        };
+        Error::from_result(res).map(|()| {
+            let min = unsafe { min.assume_init() };
+            let max = unsafe { max.assume_init() };
+            min..=max
+        })
     }
     #[doc(alias = "GetGPUTotalBoardPowerRange")]
-    pub fn gpu_total_board_power_range(&self) -> Result<std::ops::Range<i32>> {
-        unsafe {
-            let mut min = MaybeUninit::uninit();
-            let mut max = MaybeUninit::uninit();
-            let res = (self.vtable().GetGPUTotalBoardPowerRange.unwrap())(
+    pub fn gpu_total_board_power_range(&self) -> Result<std::ops::RangeInclusive<i32>> {
+        let mut min = MaybeUninit::uninit();
+        let mut max = MaybeUninit::uninit();
+        let res = unsafe {
+            (self.vtable().GetGPUTotalBoardPowerRange.unwrap())(
                 self.as_raw(),
                 min.as_mut_ptr(),
                 max.as_mut_ptr(),
-            );
-            Error::from_result(res).map(|()| {
-                let min = min.assume_init();
-                let max = max.assume_init();
-                min..max
-            })
-        }
+            )
+        };
+        Error::from_result(res).map(|()| {
+            let min = unsafe { min.assume_init() };
+            let max = unsafe { max.assume_init() };
+            min..=max
+        })
     }
     #[doc(alias = "GetGPUIntakeTemperatureRange")]
-    pub fn gpu_intake_temperature_range(&self) -> Result<std::ops::Range<i32>> {
-        unsafe {
-            let mut min = MaybeUninit::uninit();
-            let mut max = MaybeUninit::uninit();
-            let res = (self.vtable().GetGPUIntakeTemperatureRange.unwrap())(
+    pub fn gpu_intake_temperature_range(&self) -> Result<std::ops::RangeInclusive<i32>> {
+        let mut min = MaybeUninit::uninit();
+        let mut max = MaybeUninit::uninit();
+        let res = unsafe {
+            (self.vtable().GetGPUIntakeTemperatureRange.unwrap())(
                 self.as_raw(),
                 min.as_mut_ptr(),
                 max.as_mut_ptr(),
-            );
-            Error::from_result(res).map(|()| {
-                let min = min.assume_init();
-                let max = max.assume_init();
-                min..max
-            })
-        }
+            )
+        };
+        Error::from_result(res).map(|()| {
+            let min = unsafe { min.assume_init() };
+            let max = unsafe { max.assume_init() };
+            min..=max
+        })
     }
 }

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -89,8 +89,8 @@ impl AdlxHelper {
         let version = unsafe {
             let mut version = MaybeUninit::uninit();
             let result = (functions.version_fn.unwrap())(version.as_mut_ptr());
-            Error::from_result_with_assume_init_on_success(result, version)
-                .map(|version| CStr::from_ptr(version).to_str().unwrap().to_string())?
+            let version = Error::from_result_with_assume_init_on_success(result, version)?;
+            CStr::from_ptr(version).to_str().unwrap().to_string()
         };
 
         // TODO: C++ helper does extra things if an ADL context is provided.
@@ -102,7 +102,7 @@ impl AdlxHelper {
 
             System::from_raw(system)
         };
-        
+
         Ok(AdlxHelper {
             functions,
 

--- a/src/performance_monitoring_services.rs
+++ b/src/performance_monitoring_services.rs
@@ -1,11 +1,9 @@
 use std::mem::MaybeUninit;
 
-use crate::gpu_metrics::{GpuMetricsList, GpuMetricsSupport};
-
 use super::{
     ffi,
     gpu::Gpu,
-    gpu_metrics::GpuMetrics,
+    gpu_metrics::{GpuMetrics, GpuMetricsList, GpuMetricsSupport},
     interface::{Interface, InterfaceImpl},
     result::{Error, Result},
 };


### PR DESCRIPTION
- Reduce the size of some `unsafe` blocks;
- (Again) drop all string copies: all functions declare that the returned string lives as long as its parent, which Rust represents by the implicit lifetime parameter on `&str` that is equal to that of `&self`;
- Make all `ops::Range` return a `RangeInclusive` instead, as these APIs sound like they return an exclusive upper bound (but please sanity-check, I haven't tested this yet).

Another interesting avenue to wander is whether these types are actually thread-safe after adding `Send`/`Sync` (note that `&mut self` borrows don't mean much thanks to refcount `Clone`s).
