### PR TITLE
🔊 Extract PCI address (BDF) from `unique_id()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,13 @@ rust-version = "1.74"
 [dependencies]
 anyhow = "1.0.79"
 libloading = "0.8"
+windows = { version = "0.58", optional = true, features = ["Win32_Foundation", "Win32_System_LibraryLoader", "Wdk_Graphics_Direct3D"]}
 
 [workspace]
 members = [
     "api_gen"
 ]
+
+[features]
+default = ["windows_rs"]
+windows_rs = ["dep:windows"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,8 @@ rust-version = "1.74"
 [dependencies]
 anyhow = "1.0.79"
 libloading = "0.8"
-windows = { version = "0.58", optional = true, features = ["Win32_Foundation", "Win32_System_LibraryLoader", "Wdk_Graphics_Direct3D"]}
 
 [workspace]
 members = [
     "api_gen"
 ]
-
-[features]
-windows_rs = ["dep:windows"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,4 @@ members = [
 ]
 
 [features]
-default = ["windows_rs"]
 windows_rs = ["dep:windows"]


### PR DESCRIPTION
Depends on https://github.com/Traverse-Research/adlx-rs/pull/20.

This adds a windows only function to query the LUID of a device. Useful for matching against Vulkan and Dx12 devices.
Note: untested as of yet.