### PR TITLE
interface: Fix unintended release (crash) when calling `cast()`

### DIFF
--- a/examples/system.rs
+++ b/examples/system.rs
@@ -20,7 +20,6 @@ fn main() -> Result<()> {
             let gpu = gpu_list.at(i)?;
             println!("GPU #{}: {}", i, gpu.name()?);
 
-            // Crashes
             let gpu1 = gpu.cast::<Gpu1>();
             dbg!(&gpu1);
             if let Ok(gpu1) = gpu1 {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -67,7 +67,7 @@ pub unsafe trait Interface: Sized {
     // TODO(Marijn): Or deref every interface to `InterfaceImpl`, per a true interface hierarchy?
     #[doc(alias = "QueryInterface")]
     fn cast<I: Interface>(&self) -> Result<I> {
-        let interface: InterfaceImpl = unsafe { std::mem::transmute_copy(self) };
+        let interface: &InterfaceImpl = unsafe { std::mem::transmute(self) };
         interface.cast()
     }
 }


### PR DESCRIPTION
When `transmute_copy()`ing into a local/temporary `InterfaceImpl` (the generic `IADLXInterface` wrapper to call `.cast()` on), that has drop semantics and will release the interface one too many times (because it wasn't created with something like `Clone` which bumps the refcount).

By fixing that the example now no longer SEGFAULTs after querying a `Gpu1` from `Gpu` and dropping it one too many times at the end of the loop.
